### PR TITLE
fix: zoom level updated to fit popup

### DIFF
--- a/app/components/Marker/MarkerComponent.tsx
+++ b/app/components/Marker/MarkerComponent.tsx
@@ -47,7 +47,7 @@ const MarkerComponent: FC<MarkerProps> = ({ position, icon, chargingStationId })
 
     const newLat = (position as Leaflet.LatLngTuple)?.[0] + 0.005;
 
-    map.flyTo([newLat, (position as Leaflet.LatLngTuple)?.[1]], 14);
+    map.flyTo([newLat, (position as Leaflet.LatLngTuple)?.[1]], 15);
 
     if (!mdUp) {
       actions.setMarkerBottomSheetOpen(true);


### PR DESCRIPTION
The popup was not being fit in the screen for Macbook Air.
New vs Old:
<img width="1677" alt="image" src="https://github.com/user-attachments/assets/c99ea826-03d9-4411-ace4-344846fc254d">
<img width="1677" alt="image" src="https://github.com/user-attachments/assets/6b74ccc0-9abf-4c79-a036-033ffd06222f">
